### PR TITLE
fix duped up logic

### DIFF
--- a/lib/active_record/connection_adapters/amalgalite_adapter.rb
+++ b/lib/active_record/connection_adapters/amalgalite_adapter.rb
@@ -63,7 +63,7 @@ module ActiveRecord
         private
 
         def dealloc(stmt)
-          stmt[:stmt].close unless stmt[:stmt].closed?
+          stmt[:stmt].close
         end
       end
 


### PR DESCRIPTION
stmt.close already checks if the statement is open prior to closing it